### PR TITLE
chore: enable OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,14 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
+      - name: Update npm
+        run: npm install -g npm@latest && npm --version
+
       - name: Install Dependencies
         run: pnpm install
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.RSBUILD_PLUGIN_NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Enable OIDC publishing to avoid relying on a fixed npm token.

https://github.com/npm/cli/pull/8336