### PR TITLE
feat!: publish as a pure ESM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,9 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,8 +1,5 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    { syntax: 'es2021', dts: true },
-    { format: 'cjs', syntax: 'es2021' },
-  ],
+  lib: [{ syntax: 'es2023', dts: true }],
 });


### PR DESCRIPTION
## Summary

This PR aligns the published package output with the `@vue/babel-plugin-jsx` v2 upgrade. Since that dependency no longer ships a CJS build, this change removes the generated CJS bundle and updates the package exports so the plugin is published as Pure ESM only.

## Testing

- `pnpm build`

## Related Links

- https://github.com/rstackjs/rsbuild-plugin-vue-jsx/pull/33
- https://github.com/vuejs/babel-plugin-jsx/releases/tag/v2.0.1