### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rsbuild/plugin-vue": "1.2.9",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -696,6 +699,9 @@ packages:
 
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -1869,6 +1875,8 @@ snapshots:
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.0': {}
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,1 +1,0 @@
-export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,14 +1,1 @@
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/jsx-basic/rsbuild.config.ts
+++ b/test/jsx-basic/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/jsx-basic/rsbuild.config.ts
+++ b/test/jsx-basic/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue } from '@rsbuild/plugin-vue';
 import { pluginVueJsx } from '@rsbuild/plugin-vue-jsx';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [

--- a/test/jsx-hmr/index.test.ts
+++ b/test/jsx-hmr/index.test.ts
@@ -1,8 +1,8 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
 import { expect, test } from '@rstest/playwright';
+import { editFile as editSharedFile, waitFor } from '@rstackjs/test-utils';
 import { chromium, type Browser, type Page } from 'playwright';
 import { getRandomPort } from '../helper';
 
@@ -14,7 +14,7 @@ test('should render', async ({ page }) => {
     rsbuildConfig: {
       ...(await loadConfig({ cwd: __dirname })).content,
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });
@@ -41,7 +41,7 @@ test('should update', async ({ page }) => {
     rsbuildConfig: {
       ...(await loadConfig({ cwd: __dirname })).content,
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });
@@ -85,7 +85,7 @@ test.describe('vue jsx hmr', () => {
       rsbuildConfig: {
         ...(await loadConfig({ cwd: __dirname })).content,
         server: {
-          port: getRandomPort(),
+          port: await getRandomPort(),
         },
       },
     });
@@ -98,19 +98,19 @@ test.describe('vue jsx hmr', () => {
 
   test.afterAll(async () => {
     // reset files
-    editFile('Comps.jsx', (code) =>
+    await editFile('Comps.jsx', (code) =>
       code.replace('named updated {count', 'named {count'),
     );
-    editFile('Comps.jsx', (code) =>
+    await editFile('Comps.jsx', (code) =>
       code.replace('named specifier updated {count', 'named specifier {count'),
     );
-    editFile('Comps.jsx', (code) =>
+    await editFile('Comps.jsx', (code) =>
       code.replace('default updated {count', 'default {count'),
     );
-    editFile('Comp.tsx', (code) =>
+    await editFile('Comp.tsx', (code) =>
       code.replace('default tsx updated {count', 'default tsx {count'),
     );
-    editFile('setup-syntax-jsx.vue', (code) =>
+    await editFile('setup-syntax-jsx.vue', (code) =>
       code.replace('let count = ref(1000)', 'let count = ref(100)'),
     );
 
@@ -131,7 +131,7 @@ test.describe('vue jsx hmr', () => {
     await page.locator('.default-tsx').click();
     await expect(page.locator('.default-tsx')).toHaveText('default tsx 4');
 
-    editFile('Comps.jsx', (code) =>
+    await editFile('Comps.jsx', (code) =>
       code.replace('named {count', 'named updated {count'),
     );
     await untilUpdated(() => page.textContent('.named'), 'named updated 0');
@@ -146,7 +146,7 @@ test.describe('vue jsx hmr', () => {
   });
 
   test('hmr: named export via specifier', async () => {
-    editFile('Comps.jsx', (code) =>
+    await editFile('Comps.jsx', (code) =>
       code.replace('named specifier {count', 'named specifier updated {count'),
     );
     await untilUpdated(
@@ -161,7 +161,7 @@ test.describe('vue jsx hmr', () => {
   });
 
   test('hmr: default export', async () => {
-    editFile('Comps.jsx', (code) =>
+    await editFile('Comps.jsx', (code) =>
       code.replace('default {count', 'default updated {count'),
     );
     await untilUpdated(() => page.textContent('.default'), 'default updated 2');
@@ -174,7 +174,7 @@ test.describe('vue jsx hmr', () => {
     await page.locator('.named').click();
     await expect(page.locator('.named')).toHaveText('named updated 1');
 
-    editFile('Comp.tsx', (code) =>
+    await editFile('Comp.tsx', (code) =>
       code.replace('default tsx {count', 'default tsx updated {count'),
     );
     await untilUpdated(
@@ -192,14 +192,14 @@ test.describe('vue jsx hmr', () => {
     await page.locator('.script').click();
     await expect(page.locator('.script')).toHaveText('script 5');
 
-    editFile('Script.vue', (code) =>
+    await editFile('Script.vue', (code) =>
       code.replace('script {count', 'script updated {count'),
     );
 
     await untilUpdated(() => page.textContent('.script'), 'script updated 4');
 
     // reset code
-    editFile('Script.vue', (code) =>
+    await editFile('Script.vue', (code) =>
       code.replace('script updated {count', 'script {count'),
     );
   });
@@ -209,7 +209,7 @@ test.describe('vue jsx hmr', () => {
     await page.locator('.src-import').click();
     await expect(page.locator('.src-import')).toHaveText('src import 6');
 
-    editFile('Script.vue', (code) =>
+    await editFile('Script.vue', (code) =>
       code.replace('script {count', 'script updated {count'),
     );
     await untilUpdated(() => page.textContent('.script'), 'script updated 4');
@@ -217,7 +217,7 @@ test.describe('vue jsx hmr', () => {
     await expect(page.locator('.src-import')).toHaveText('src import 6');
 
     // reset code
-    editFile('Script.vue', (code) =>
+    await editFile('Script.vue', (code) =>
       code.replace('script updated {count', 'script {count'),
     );
   });
@@ -227,7 +227,7 @@ test.describe('vue jsx hmr', () => {
     await page.locator('.script').click();
     await expect(page.locator('.script')).toHaveText('script 5');
 
-    editFile('SrcImport.jsx', (code) =>
+    await editFile('SrcImport.jsx', (code) =>
       code.replace('src import {count', 'src import updated {count'),
     );
 
@@ -239,13 +239,13 @@ test.describe('vue jsx hmr', () => {
     await expect(page.locator('.script')).toHaveText('script 5');
 
     // reset code
-    editFile('SrcImport.jsx', (code) =>
+    await editFile('SrcImport.jsx', (code) =>
       code.replace('src import updated {count', 'src import {count'),
     );
   });
 
   test('hmr: setup jsx in .vue', async () => {
-    editFile('setup-syntax-jsx.vue', (code) =>
+    await editFile('setup-syntax-jsx.vue', (code) =>
       code.replace('let count = ref(100)', 'let count = ref(1000)'),
     );
 
@@ -253,27 +253,25 @@ test.describe('vue jsx hmr', () => {
   });
 });
 
-function editFile(filename: string, replacer: (str: string) => string): void {
+function editFile(
+  filename: string,
+  replacer: (str: string) => string,
+): Promise<void> {
   const fileName = path.join(__dirname, 'src', filename);
-  const content = fs.readFileSync(fileName, 'utf-8');
-  const modified = replacer(content);
-  fs.writeFileSync(fileName, modified);
+  return editSharedFile(fileName, replacer);
 }
-
-const timeout = (n: number) => new Promise((r) => setTimeout(r, n));
 
 async function untilUpdated(
   poll: () => Promise<string | null>,
   expected: string,
 ): Promise<void> {
-  const maxTries = 50;
-  for (let tries = 0; tries < maxTries; tries++) {
-    const actual = (await poll()) ?? '';
-    if (actual.indexOf(expected) > -1 || tries === maxTries - 1) {
-      expect(actual).toMatch(expected);
-      break;
-    }
-
-    await timeout(50);
-  }
+  let actual = '';
+  await waitFor(
+    async () => {
+      actual = (await poll()) ?? '';
+      return actual.includes(expected);
+    },
+    { interval: 50, timeout: 2500 },
+  );
+  expect(actual).toMatch(expected);
 }

--- a/test/jsx-hmr/index.test.ts
+++ b/test/jsx-hmr/index.test.ts
@@ -4,7 +4,7 @@ import { createRsbuild, loadConfig } from '@rsbuild/core';
 import { expect, test } from '@rstest/playwright';
 import { editFile as editSharedFile, waitFor } from '@rstackjs/test-utils';
 import { chromium, type Browser, type Page } from 'playwright';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/test/sfc-lang-jsx/rsbuild.config.ts
+++ b/test/sfc-lang-jsx/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-jsx/rsbuild.config.ts
+++ b/test/sfc-lang-jsx/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue } from '@rsbuild/plugin-vue';
 import { pluginVueJsx } from '@rsbuild/plugin-vue-jsx';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [

--- a/test/sfc-lang-tsx/rsbuild.config.ts
+++ b/test/sfc-lang-tsx/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-tsx/rsbuild.config.ts
+++ b/test/sfc-lang-tsx/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue } from '@rsbuild/plugin-vue';
 import { pluginVueJsx } from '@rsbuild/plugin-vue-jsx';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
This PR replaces duplicated test helpers with `@rstackjs/test-utils`, including available-port selection, file edits, and HMR polling. Async call sites now await the shared helpers.